### PR TITLE
Remove two options of editors that are not good for beginners

### DIFF
--- a/Week0/README.md
+++ b/Week0/README.md
@@ -65,9 +65,7 @@
 
 Any of the ones listed below is fine.
 - [Visual studio](https://code.visualstudio.com/)
-- [Brackets](http://brackets.io)
 - [Atom](https://atom.io/)
-- [Spacemacs](http://spacemacs.org/)
 - [Sublime (not free)](https://www.sublimetext.com/)
 
 If you have no experience or preference when it comes to working with text editor just install Visual studio, you can always switch to another editor later on in the program.


### PR DESCRIPTION
I can't recommend emacs for beginners as it is a terminal editor with advanced editing features.
And Brackets does not offer anything that Atom, VS Code or Sublime does not do better.