### PR TITLE
Fix flexbox link

### DIFF
--- a/Week2/preparation.md
+++ b/Week2/preparation.md
@@ -9,7 +9,7 @@ In week two we will discuss the following topics
 
 ### Here are resources that we like you to read as a preparation for the coming lecture:
 - Start reading about media queries here: [Introduction to Media Queries](https://varvy.com/mobile/media-queries.html). 
-- And read about [flexbox](https://tympanus.net/codrops/css_reference/flexbox/And) 
+- And read about [flexbox](https://tympanus.net/codrops/css_reference/flexbox)
 - Also take a look at this [website](http://mediaqueri.es) here you can find examples of responsive design.
 
 _Please go through the material and come to class prepared!_


### PR DESCRIPTION
The current link ends up resolving to `https://tympanus.net/codrops/2009/10/21/and-what-about-resolution/`.